### PR TITLE
broken reference url for constituent

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         <div class="well">
           <h3>Constituent: {{ constituent.name }}</h3>
           <p>
-            See <a href="https://developer.sky.blackbaud.com/docs/services/56b76470069a0509c8f1c5b3/operations/56b76471069a050520297715" target="_blank">Constituent</a>
+            See <a href="https://developer.blackbaud.com/skyapi/apis/constituent/entities#Constituent" target="_blank">Constituent</a>
             within the Blackbaud SKY API contact reference for a full listing of properties.
           </p>
         </div>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         <div class="well">
           <h3>Constituent: {{ constituent.name }}</h3>
           <p>
-            See <a href="https://developer.sky.blackbaud.com/constituent-entity-reference#Constituent" target="_blank">Constituent</a>
+            See <a href="https://developer.sky.blackbaud.com/docs/services/56b76470069a0509c8f1c5b3/operations/56b76471069a050520297715" target="_blank">Constituent</a>
             within the Blackbaud SKY API contact reference for a full listing of properties.
           </p>
         </div>


### PR DESCRIPTION
Found a reference URL for the Constituent API that is no longer working. Hopefully added the correct URL.